### PR TITLE
feat: add isRouteAppoved approveRoute & send support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,7 +273,7 @@ export class Squid {
       : ethers.BigNumber.from(gasFee);
 
     const tx = {
-      to: sourceChain.squidContracts.squidMain,
+      to: spenderContractAddress,
       data: transactionRequest.data,
       value: value,
       gasLimit: 60e4 // 600000 gasLimit

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,8 +255,6 @@ export class Squid {
         transactionRequest.destinationChainGas
       );
     } catch (error) {
-      // TODO: we need a backup
-      console.warn("error: fetching gasFee:", error);
       gasFee = "3513000021000000";
     }
 
@@ -266,12 +264,18 @@ export class Squid {
         )
       : ethers.BigNumber.from(gasFee);
 
-    const tx = {
+    let tx = {
       to: targetAddress,
       data: transactionRequest.data,
-      value: value,
       gasLimit: 60e4 // 600000 gasLimit
-    };
+    } as ethers.utils.Deferrable<ethers.providers.TransactionRequest>;
+
+    if (transactionRequest.routeType !== "SEND") {
+      tx = {
+        ...tx,
+        value
+      };
+    }
 
     return await signer.sendTransaction(tx);
   }

--- a/src/test/approve.spec.ts
+++ b/src/test/approve.spec.ts
@@ -37,7 +37,8 @@ describe("SquidSdk approve method", () => {
     const approval = await squidSdk.approve({
       signer: {} as ethers.Wallet,
       spender: "0x6972A415e0572bd2E5E3c7DF307d0AFe32D30955",
-      tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      chainId: 1
     });
 
     expect(mockedApprove).toHaveBeenCalledWith(
@@ -56,6 +57,7 @@ describe("SquidSdk approve method", () => {
       signer: {} as ethers.Wallet,
       spender: "0x6972A415e0572bd2E5E3c7DF307d0AFe32D30955",
       tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      chainId: 1,
       amount: "100"
     });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,6 +119,7 @@ export type Allowance = {
   owner: string;
   spender: string;
   tokenAddress: string;
+  chainId: number;
 };
 
 export type Approve = {
@@ -126,4 +127,44 @@ export type Approve = {
   spender: string;
   tokenAddress: string;
   amount?: string;
+  chainId: number;
+};
+
+export enum RouteType {
+  TRADE_SEND_TRADE = "TRADE_SEND_TRADE",
+  TRADE_SEND = "TRADE_SEND",
+  SEND_TRADE = "SEND_TRADE",
+  SEND = "SEND"
+}
+
+export type IsRouteApproved = {
+  route: Route;
+  sender: string;
+};
+
+export type ApproveRoute = {
+  route: Route;
+  signer: ethers.Wallet;
+};
+
+export type RoutePopulatedData = {
+  sourceChain: ChainData;
+  destinationChain: ChainData;
+  sourceToken: TokenData | undefined;
+  destinationToken: TokenData | undefined;
+  srcTokenContract: ethers.Contract | undefined;
+  srcProvider: ethers.providers.JsonRpcProvider;
+  sourceIsNative: boolean;
+  spenderContractAddress: string;
+};
+
+export type ValidateBalanceAndApproval = {
+  srcTokenContract: ethers.Contract;
+  srcProvider: ethers.providers.JsonRpcProvider;
+  sourceIsNative: boolean;
+  sourceAmount: string;
+  spenderContractAddress: string;
+  signer: ethers.Wallet;
+  sourceChain: ChainData;
+  infiniteApproval?: boolean;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,7 @@ export type RouteData = {
 
 export type TransactionRequest = {
   routeType: string;
+  targetAddress: string;
   gasReceiver: boolean;
   data: string;
   destinationChainGas: number;
@@ -130,13 +131,6 @@ export type Approve = {
   chainId: number;
 };
 
-export enum RouteType {
-  TRADE_SEND_TRADE = "TRADE_SEND_TRADE",
-  TRADE_SEND = "TRADE_SEND",
-  SEND_TRADE = "SEND_TRADE",
-  SEND = "SEND"
-}
-
 export type IsRouteApproved = {
   route: Route;
   sender: string;
@@ -155,7 +149,7 @@ export type RoutePopulatedData = {
   srcTokenContract: ethers.Contract | undefined;
   srcProvider: ethers.providers.JsonRpcProvider;
   sourceIsNative: boolean;
-  spenderContractAddress: string;
+  targetAddress: string;
 };
 
 export type ValidateBalanceAndApproval = {
@@ -163,7 +157,7 @@ export type ValidateBalanceAndApproval = {
   srcProvider: ethers.providers.JsonRpcProvider;
   sourceIsNative: boolean;
   sourceAmount: string;
-  spenderContractAddress: string;
+  targetAddress: string;
   signer: ethers.Wallet;
   sourceChain: ChainData;
   infiniteApproval?: boolean;

--- a/src/utils/getTokenData.ts
+++ b/src/utils/getTokenData.ts
@@ -2,6 +2,10 @@ import { TokenData } from "../types";
 
 export const getTokenData = (
   tokens: TokenData[],
-  address: string
+  address: string,
+  chainId: number
 ): TokenData | undefined =>
-  tokens.find(e => e.address.toLowerCase() === address.toLowerCase());
+  tokens.find(
+    e =>
+      e.address.toLowerCase() === address.toLowerCase() && e.chainId === chainId
+  );

--- a/test-sdk.ts
+++ b/test-sdk.ts
@@ -6,8 +6,8 @@ import { Squid } from "./src";
 
 dotenv.config();
 
-const sendAmount: BigNumber = ethers.utils.parseEther("1"); // 0.1 WETH
-// const aUSDC: BigNumber = ethers.utils.parseUnits('1', 6) // 1 aUSDC
+// const sendAmount: BigNumber = ethers.utils.parseEther("1"); // 0.1 WETH
+const USDC: BigNumber = ethers.utils.parseUnits("100", 6); // 1 USDC
 
 const privateKey = process.env.privateKey as string;
 const ethereumRpcEndPoint = process.env.ethereumRpcEndPoint as string;
@@ -26,8 +26,8 @@ async function main() {
   const params = {
     recipientAddress: signer.address,
     sourceChainId: 1,
-    sourceTokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    sourceAmount: sendAmount.toString(),
+    sourceTokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    sourceAmount: USDC.toString(),
     destinationChainId: 1284,
     destinationTokenAddress: "0xCa01a1D0993565291051daFF390892518ACfAD3A",
     slippage: 1
@@ -50,8 +50,8 @@ async function main() {
   // const params = {
   //   recipientAddress,
   //   sourceChainId: 1,
-  //   sourceTokenAddress: squidSdk.tokens?.find(t => t.symbol === 'aUSDC')?.address as string,
-  //   sourceAmount: aUSDC,
+  //   sourceTokenAddress: squidSdk.tokens?.find(t => t.symbol === 'USDC')?.address as string,
+  //   sourceAmount: USDC,
   //   destinationChainId: 43114,
   //   destinationTokenAddress: squidSdk.tokens?.find(t => t.symbol === 'axlUSDC')?.address as string,
   //   slippage: 1


### PR DESCRIPTION
# Description

Creation of `isRouteAppoved` & `approveRoute` methods

As I detect lot of repeated code I create the `validateRouteData` private method that retrieves all the data to be consumen inside of the public methods

Finally I also add support to send only feat, as this show interact directly with the axelar gateway and not squid main contract

- closes #208
- Zenhub issue: [128](https://app.zenhub.com/workspaces/squid-62f41ece0f99c000158e872d/issues/0xsquid/squid-core/128) [208](https://app.zenhub.com/workspaces/squid-62f41ece0f99c000158e872d/issues/0xsquid/squid-core/208) [166](https://app.zenhub.com/workspaces/squid-62f41ece0f99c000158e872d/issues/0xsquid/squid-core/166)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code improvement)
- [ ] Styles (adding, editing or fixing styles)
- [ ] Unit test

# How Has This Been Tested?

Please describe the steps to test.

## Evidence

Please add some evidence like screenshots or records.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
