### PR TITLE
Fix: transactionRequest validation quoteOnly

### DIFF
--- a/src/0xsquid/v1/route.ts
+++ b/src/0xsquid/v1/route.ts
@@ -250,12 +250,14 @@ export const parseRouteResponse = (response: any): RouteResponse => {
   const {
     route: { estimate, transactionRequest, params }
   } = response;
-  const routeResponse = {
+  const routeResponse = removeEmpty({
     route: {
       estimate: parseEstimate(estimate),
-      transactionRequest: parseTransactionRequest(transactionRequest),
+      transactionRequest: transactionRequest
+        ? parseTransactionRequest(transactionRequest)
+        : undefined,
       params: parseParams(params)
     }
-  };
+  });
   return routeResponse;
 };

--- a/src/0xsquid/v1/route.ts
+++ b/src/0xsquid/v1/route.ts
@@ -250,7 +250,7 @@ export const parseRouteResponse = (response: any): RouteResponse => {
   const {
     route: { estimate, transactionRequest, params }
   } = response;
-  const routeResponse = removeEmpty({
+  const routeResponse = {
     route: {
       estimate: parseEstimate(estimate),
       transactionRequest: transactionRequest
@@ -258,6 +258,6 @@ export const parseRouteResponse = (response: any): RouteResponse => {
         : undefined,
       params: parseParams(params)
     }
-  });
+  };
   return routeResponse;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,15 @@ export class Squid {
   }: ExecuteRoute): Promise<ethers.providers.TransactionResponse> {
     this.validateInit();
 
+    if (!route.transactionRequest) {
+      throw new SquidError({
+        message: `transactionRequest property is missing in route object`,
+        errorType: ErrorType.ValidationError,
+        logging: this.config.logging,
+        logLevel: this.config.logLevel
+      });
+    }
+
     const { transactionRequest, params } = route;
 
     const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   TokenData,
   IsRouteApproved,
   RouteData,
-  RoutePopulatedData,
+  RouteParamsData,
   ValidateBalanceAndApproval,
   ChainData,
   RouteParams,
@@ -139,7 +139,7 @@ export class Squid {
     }
   }
 
-  private validateRouteData(params: RouteParams): RoutePopulatedData {
+  private validateRouteParams(params: RouteParams): RouteParamsData {
     const { fromChain, toChain, fromToken, toToken } = params;
 
     const _fromChain = getChainData(
@@ -267,7 +267,7 @@ export class Squid {
     const { transactionRequest, params } = route;
 
     const { fromIsNative, fromChain, fromTokenContract, fromProvider } =
-      this.validateRouteData(route.params);
+      this.validateRouteParams(route.params);
 
     const {
       targetAddress,
@@ -329,7 +329,7 @@ export class Squid {
     this.validateInit();
 
     const { fromIsNative, fromChain, fromProvider, fromTokenContract } =
-      this.validateRouteData(route.params);
+      this.validateRouteParams(route.params);
     const { targetAddress } = this.validateTransactionRequest(
       route.transactionRequest
     );
@@ -401,7 +401,7 @@ export class Squid {
   }: ApproveRoute): Promise<boolean> {
     this.validateInit();
 
-    const { fromIsNative, fromTokenContract } = this.validateRouteData(
+    const { fromIsNative, fromTokenContract } = this.validateRouteParams(
       route.params
     );
     const targetAddress = this.validateTransactionRequest(

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export class Squid {
       maxPriorityFeePerGas,
       gasPrice,
       gasLimit
-    } = this.validateTransactionRequest(transactionRequest);
+    } = route.transactionRequest;
 
     let _gasParams = {};
     if (executionSettings?.setGasPrice) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -266,7 +266,7 @@ export type RouteParams = GetRoute & {
 
 export type RouteData = {
   estimate: Estimate;
-  transactionRequest: TransactionRequest;
+  transactionRequest?: TransactionRequest;
   params: GetRoute & { fromToken: TokenData; toToken: TokenData };
 };
 
@@ -341,7 +341,6 @@ export type RoutePopulatedData = {
   fromTokenContract: ethers.Contract | undefined;
   fromProvider: ethers.providers.JsonRpcProvider;
   fromIsNative: boolean;
-  targetAddress: string;
 };
 
 export type ValidateBalanceAndApproval = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -333,7 +333,7 @@ export type ApproveRoute = {
   overrides?: OverrideParams;
 };
 
-export type RoutePopulatedData = {
+export type RouteParamsData = {
   fromChain: ChainData;
   toChain: ChainData;
   fromToken: TokenData | undefined;


### PR DESCRIPTION
# Description

Fix the bug where the getRoute fails if quoteOnly flag is true. The fix is to refactor code and remove validation for transactionRequest property in validateRouteParam 

- closes 0xsquid/squid-core #820
- Zenhub issue: #820
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement)
- [ ] Styles (adding, editing or fixing styles)
- [ ] Unit test

# How Has This Been Tested?

Please describe the steps to test.

## Evidence

Please add some evidence like screenshots or records.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
