### PR TITLE
fix: handle undefined chaindata in parse status

### DIFF
--- a/src/0xsquid/v1/status.ts
+++ b/src/0xsquid/v1/status.ts
@@ -25,7 +25,7 @@ export const parseTransactionStatus = (data: any) => {
     blockNumber,
     callEventStatus,
     callEventLog,
-    chainData: parseChainData([chainData]).pop(),
+    chainData: chainData ? parseChainData([chainData]).pop() : undefined,
     transactionUrl
   }) as TransactionStatus;
 };


### PR DESCRIPTION
# Description

- fix a bug when chain data object is undefined in status api response

- closes 0xsquid/squid-core# (issue number)
- Zenhub issue: (optional)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement)
- [ ] Styles (adding, editing or fixing styles)
- [ ] Unit test

# How Has This Been Tested?

Please describe the steps to test.

## Evidence

Please add some evidence like screenshots or records.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
