### PR TITLE
feat: add method to get from amount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import {
   RouteRequest,
   RouteResponse,
   StatusResponse,
-  EvmWallet
+  EvmWallet,
+  Token
 } from "./types";
 
 import HttpAdapter from "./adapter/HttpAdapter";
@@ -273,5 +274,31 @@ export class Squid extends TokensChains {
     if (!route.transactionRequest) {
       throw new Error("transactionRequest param not found in route object");
     }
+  }
+
+  public getFromAmount({
+    fromToken,
+    toAmount,
+    toToken,
+    slippagePercentage = 1.5
+  }: {
+    fromToken: Token;
+    toToken: Token;
+    toAmount: string;
+    slippagePercentage?: number;
+  }): string {
+    const toTokenPrice = Number(toToken.usdPrice ?? 0);
+    const fromTokenPrice = Number(fromToken.usdPrice ?? 0);
+
+    // example fromAmount: 10
+    const fromAmount = (toTokenPrice * Number(toAmount ?? 0)) / fromTokenPrice;
+
+    // fromAmount (10) * slippagePercentage (1.5) / 100 = 0.15
+    const slippage = fromAmount * (slippagePercentage / 100);
+
+    // fromAmount (10) + slippage (0.15) = 10.15
+    const fromAmountPlusSlippage = fromAmount + slippage;
+
+    return fromAmountPlusSlippage.toString();
   }
 }


### PR DESCRIPTION
# Description

Get a `fromAmount` based on `fromToken`, `toToken` and `toAmount`.

Example usage:

```js
const ETH = squid.getTokenData(
  "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
  "1"
);

const USDC = squid.getTokenData(
  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  "1"
);

const usdcToEth = await squid.getFromAmount({
  fromToken: USDC,
  toAmount: "1",
  toToken: ETH
}); // expected: ~1600

const ethToUsdc = await squid.getFromAmount({
  fromToken: ETH,
  toAmount: "200",
  toToken: USDC
}); // expected: ~0.12...

// you can also specify slippage percentage (default is 1.5%)
const usdcToEth3 = await squid.getFromAmount({
  fromToken: USDC,
  toAmount: "1",
  toToken: ETH,
  slippagePercentage: 3
}); // expected: ~1648
```
- closes 0xsquid/squid-core#2487
- [Zenhub issue](https://app.zenhub.com/workspaces/squid-62f41ece0f99c000158e872d/issues/gh/0xsquid/squid-core/2487)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
