### PR TITLE
fix: use all chains when no chains are specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -764,13 +764,17 @@ export class Squid {
 
   public async getAllEvmBalances({
     userAddress,
-    chains
+    chains = []
   }: {
     userAddress: string;
-    chains: (string | number)[];
+    chains?: (string | number)[];
   }): Promise<TokenBalance[]> {
+    // if no chains are provided, use all chains
+    const chainIds =
+      chains.length === 0 ? this.chains.map(t => String(t.chainId)) : chains;
+
     // remove invalid and duplicate chains and convert to number
-    const filteredChains = new Set(chains.map(Number).filter(c => !isNaN(c)));
+    const filteredChains = new Set(chainIds.map(Number).filter(c => !isNaN(c)));
     const chainRpcUrls = this.chains.reduce(
       (acc, chain) => ({
         ...acc,
@@ -809,7 +813,7 @@ export class Squid {
   }
 
   public async getAllBalances({
-    chainIds,
+    chainIds = [],
     cosmosAddresses,
     evmAddress
   }: {
@@ -820,27 +824,6 @@ export class Squid {
     cosmosBalances?: CosmosBalance[];
     evmBalances?: TokenBalance[];
   }> {
-    if (!chainIds) {
-      // fetch balances for all chains compatible with provided addresses
-      const evmBalances = evmAddress
-        ? await this.getAllEvmBalances({
-            chains: this.tokens.map(t => String(t.chainId)),
-            userAddress: evmAddress
-          })
-        : [];
-
-      const cosmosBalances = cosmosAddresses
-        ? await this.getAllCosmosBalances({
-            addresses: cosmosAddresses
-          })
-        : [];
-
-      return {
-        evmBalances,
-        cosmosBalances
-      };
-    }
-
     const normalizedChainIds = chainIds.map(String);
 
     // fetch balances for provided chains


### PR DESCRIPTION
# Description

If no chains are provided to `getAllBalances`, `getAllCosmosBalances`, and `getAllEvmBalances`, use all chains by default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This snippet fetches balances for all EVM and Cosmos chains:
```js
const allBalances = await squid.getAllBalances({
  cosmosAddresses: [
    {
      address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5",
      chainId: "cosmoshub-3",
      coinType: 118
    }
  ],
  evmAddress: "0x344b63c2BcB4B61765083735e8F49Bb203415a33"
});
```

This snippet fetches balances for all EVM chains:
```js
const evmBalance = await squid.getAllEvmBalances({
  userAddress: "0x344b63c2BcB4B61765083735e8F49Bb203415a33"
});
```

This snippet fetches balances for all Cosmos chains:
```js
const cosmosBalance = await squid.getAllCosmosBalances({
  addresses: [
    {
      address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5",
      chainId: "cosmoshub-3",
      coinType: 118
    }
  ]
});
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
