### PR TITLE
feat (v2): add chainId property to evm balances response

### DIFF
--- a/src/handlers/evm/utils.ts
+++ b/src/handlers/evm/utils.ts
@@ -238,14 +238,15 @@ export class Utils {
 
       if (!token) return null;
 
-      const { decimals, symbol, address } = token;
+      const { decimals, symbol, address, chainId } = token;
 
       return {
         address,
         // balance in wei
         balance: parseInt(balance, 16).toString(),
         decimals,
-        symbol
+        symbol,
+        chainId
       };
     } catch (error) {
       return null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,7 @@ export type TokenBalance = {
   address: string;
   decimals: number;
   balance: string;
+  chainId: string | number;
 };
 
 export type CosmosAddress = {


### PR DESCRIPTION
# Description

Add missing `chainId` property to evm balances response:
```diff
type TokenBalance = {
  symbol: string;
  address: string;
  decimals: number;
  balance: string;
+ chainId: string | number;
};
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
