### PR TITLE
feat: add a timeout to Config and Squid

### DIFF
--- a/src/adapter/HttpAdapter.ts
+++ b/src/adapter/HttpAdapter.ts
@@ -9,7 +9,8 @@ export default class HttpAdapter {
   constructor(config: RequestConfig) {
     this.axios = axios.create({
       ...omit(config, ["config"]),
-      baseURL: config?.baseUrl
+      baseURL: config?.baseUrl,
+      timeout: config?.timeout
     });
 
     if (config) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,8 @@ export class Squid extends TokensChains {
       config,
       headers: {
         "x-integrator-id": config.integratorId
-      }
+      },
+      timeout: config.timeout
     });
 
     this.config = {
@@ -73,7 +74,8 @@ export class Squid extends TokensChains {
       config,
       headers: {
         "x-integrator-id": config.integratorId || "squid-sdk"
-      }
+      },
+      timeout: config.timeout
     });
     this.config = {
       baseUrl: config?.baseUrl || baseUrl,

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -7,4 +7,5 @@ export interface RequestConfig {
   baseUrl?: string;
   config?: Config;
   headers?: Record<string, string | number | boolean>;
+  timeout?: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export type Config = {
   logging?: boolean;
   logLevel?: LogLevel;
   integratorId: string;
+  timeout?: number;
 };
 
 export type OverrideParams = GasData;


### PR DESCRIPTION
# Description

Optionally set an HTTP timeout.  This is helpful for maintaining responsiveness for end users, especially for apps that might leverage multiple route APIs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`yarn build && yarn test` and local end-to-end testing w/ Valora's squid integration.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
