### PR TITLE
fix: use bigNumber on getFromAmount method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -885,8 +885,7 @@ export class Squid {
    * Get the amount of tokens needed to swap to a specific amount
    * This is needed in checkout widget where we know the destination amount but not the source amount
    * The user won't modify the source amount, so we need to calculate it
-   * @param param0
-   * @returns
+   * @returns {string} The amount of tokens needed to swap to a specific amount
    */
   public async getFromAmount({
     fromToken,

--- a/src/test/fromAmount.spec.ts
+++ b/src/test/fromAmount.spec.ts
@@ -1,0 +1,104 @@
+import { Squid, TokenData } from "../index";
+
+let squid: Squid;
+
+const ETHMainnet: TokenData = {
+  chainId: 1,
+  address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+  name: "Ethereum",
+  symbol: "ETH",
+  decimals: 18,
+  logoURI: "",
+  coingeckoId: "ethereum",
+  commonKey: "weth-wei"
+};
+
+const USDCArbitrum: TokenData = {
+  chainId: 42161,
+  name: "USD Coin",
+  address: "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+  symbol: "USDC.e",
+  decimals: 6,
+  logoURI: "",
+  coingeckoId: "usd-coin"
+};
+
+describe("SquidSdk approve method", () => {
+  beforeAll(async () => {
+    squid = new Squid({
+      baseUrl: "https://api.squidrouter.com",
+      integratorId: "squid-sdk-jest-run"
+    });
+    await squid.init();
+  });
+
+  describe("getFromAmount", () => {
+    it("calculates the correct fromAmount if toAmount is very low", async () => {
+      const fromAmount = await squid.getFromAmount({
+        fromToken: ETHMainnet,
+        toToken: USDCArbitrum,
+        toAmount: "0.0001",
+        slippagePercentage: 1.5
+      });
+
+      expect(Number(fromAmount)).toBeGreaterThan(0);
+    });
+
+    it("calculates the correct fromAmount is toAmount is high", async () => {
+      const fromAmount = await squid.getFromAmount({
+        fromToken: ETHMainnet,
+        toToken: USDCArbitrum,
+        toAmount: "1000000",
+        slippagePercentage: 1.5
+      });
+
+      expect(Number(fromAmount)).toBeGreaterThan(0);
+    });
+
+    it("makes sure slippage is working", async () => {
+      const lowSlippagePercentage = 0.5;
+      const highSlippagePercentage = 80;
+
+      const expectedPercentageDifference = Math.round(
+        highSlippagePercentage - lowSlippagePercentage
+      );
+
+      const fromAmountLowSlippage = await squid.getFromAmount({
+        fromToken: ETHMainnet,
+        toToken: USDCArbitrum,
+        toAmount: "10000",
+        slippagePercentage: lowSlippagePercentage
+      });
+      const fromAmountHighSlippage = await squid.getFromAmount({
+        fromToken: ETHMainnet,
+        toToken: USDCArbitrum,
+        toAmount: "10000",
+        slippagePercentage: highSlippagePercentage
+      });
+
+      // Get the % difference between the two fromAmounts
+      const percentageDifference = Math.round(
+        ((Number(fromAmountHighSlippage) - Number(fromAmountLowSlippage)) /
+          Number(fromAmountLowSlippage)) *
+          100
+      );
+
+      // Based on USD prices, and rounded values, there could still be some differences
+      const acceptThreshold = 2;
+
+      // check how much the expected difference and the real difference are
+      const differenceBetweenExpectedAndActual = Math.abs(
+        expectedPercentageDifference - percentageDifference
+      );
+
+      // The expected difference and the real difference should be within the threshold
+      expect(differenceBetweenExpectedAndActual).toBeLessThanOrEqual(
+        acceptThreshold
+      );
+
+      expect(Number(fromAmountHighSlippage)).toBeGreaterThan(
+        Number(fromAmountLowSlippage)
+      );
+    });
+  });
+});

--- a/src/test/fromAmount.spec.ts
+++ b/src/test/fromAmount.spec.ts
@@ -44,6 +44,17 @@ describe("SquidSdk approve method", () => {
       expect(Number(fromAmount)).toBeGreaterThan(0);
     });
 
+    it("should return null if slippage is negative ", async () => {
+      const fromAmount = await squid.getFromAmount({
+        fromToken: ETHMainnet,
+        toToken: USDCArbitrum,
+        toAmount: "0.0001",
+        slippagePercentage: -1
+      });
+
+      expect(fromAmount).toBe(null);
+    });
+
     it("calculates the correct fromAmount is toAmount is high", async () => {
       const fromAmount = await squid.getFromAmount({
         fromToken: ETHMainnet,


### PR DESCRIPTION
# Description

In the previous version, we experienced fromAmount being noted for example as 4.0e-10 ETH
This was obviously breaking widget parsing before executing transaction

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement)
- [ ] Styles (adding, editing or fixing styles)
- [ ] Unit test

# How Has This Been Tested?

Tested locally with prod data on very small prices
Ex: buy item at 0.0001 axlUSDC, from ETH 
This was previously giving an error because of scientific notation
Now converting successfully to 0.0000000795343 ETH

## Evidence

Please add some evidence like screenshots or records.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
