### PR TITLE
Fix v1/multicall balances

### DIFF
--- a/src/services/getEvmBalances.ts
+++ b/src/services/getEvmBalances.ts
@@ -94,23 +94,12 @@ const getTokensBalanceWithoutMultiCall = async (
 ): Promise<TokenBalance[]> => {
   const balances: (TokenBalance | null)[] = await Promise.all(
     tokens.map(async t => {
-      let balance: TokenBalance | null;
       try {
-        if (t.address === NATIVE_EVM_TOKEN_ADDRESS) {
-          balance = await fetchBalance({
-            token: t,
-            userAddress,
-            rpcUrl: rpcUrlsPerChain[t.chainId]
-          });
-        } else {
-          balance = await fetchBalance({
-            token: t,
-            userAddress,
-            rpcUrl: rpcUrlsPerChain[t.chainId]
-          });
-        }
-
-        return balance;
+        return await fetchBalance({
+          token: t,
+          userAddress,
+          rpcUrl: rpcUrlsPerChain[t.chainId]
+        });
       } catch (error) {
         return null;
       }
@@ -199,6 +188,10 @@ async function fetchBalance({
   userAddress,
   rpcUrl
 }: FetchBalanceParams): Promise<TokenBalance | null> {
+  if (token.address.toLowerCase() === NATIVE_EVM_TOKEN_ADDRESS.toLowerCase()) {
+    return fetchNativeBalance({ token, userAddress, rpcUrl });
+  }
+
   try {
     const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
 
@@ -225,6 +218,28 @@ async function fetchBalance({
     };
   } catch (error) {
     console.error("Error fetching token balance:", error);
+    return null;
+  }
+}
+
+async function fetchNativeBalance({
+  userAddress,
+  rpcUrl,
+  token
+}: FetchBalanceParams) {
+  try {
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    const balance = await provider.getBalance(userAddress);
+
+    return {
+      address: token.address,
+      balance: balance.toString(),
+      decimals: token.decimals,
+      symbol: token.symbol,
+      chainId: token.chainId
+    };
+  } catch (error) {
+    console.error("Error fetching native token balance:", error);
     return null;
   }
 }

--- a/src/services/getEvmBalances.ts
+++ b/src/services/getEvmBalances.ts
@@ -9,7 +9,7 @@ import {
 
 type ContractAddress = `0x${string}`;
 
-const CHAINS_WITHOUT_MULTICALL = [314, 3141]; // Filecoin, & Filecoin testnet
+const CHAINS_WITHOUT_MULTICALL = [314, 3141, 2222]; // Filecoin, Filecoin testnet and Kava
 
 const getTokensBalanceSupportingMultiCall = async (
   tokens: TokenData[],


### PR DESCRIPTION
# Description

- use getBalance to fetch native tokens balance
- add Kava to the list of chains not supporting multicall

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Running this script:
```ts
import { Squid } from "@0xsquid/sdk";

(async () => {
  // instantiate the SDK
  const squid = new Squid();

  squid.setConfig({
    baseUrl: "https://api.squidrouter.com", // for mainnet use "https://api.0xsquid.com"
    integratorId: "squid-test"
  });

  // init the SDK
  await squid.init();
  console.log("Squid inited");

  const evmBalances = await squid.getAllEvmBalances({
    userAddress: "0x1f0b95d58090f3F08282c9c875519E741e7Cd045",
    chains: ["2222"]
  });

  console.log({
    evmBalances: evmBalances.filter(b => b.balance !== "0")
  });
})();
```

### Before changes
Console output:
```js
Squid inited
{
  evmBalances: [],
}
```

### After changes
Console output:
```js
Squid inited
{
  evmBalances: [
    {
      address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
      balance: "7279488416456749069",
      decimals: 18,
      symbol: "KAVA",
      chainId: 2222,
    }, {
      address: "0xEB466342C4d449BC9f53A865D5Cb90586f405215",
      balance: "302477717",
      decimals: 6,
      symbol: "axlUSDC",
      chainId: 2222,
    }
  ],
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
