### PR TITLE
added checks for chainID and error messages`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -928,6 +928,31 @@ export class Squid {
       return null;
     }
   }
+
+  public async checkSignerChainCompatibility(
+    signer: ethers.Signer | ethers.Wallet,
+    route: RouteData
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const signerChainId = await signer.getChainId();
+      const routeChainId = Number(route.params.fromChain);
+
+      if (signerChainId !== routeChainId) {
+        throw new SquidError({
+          message: `Signer is on the wrong chain ID (${signerChainId}). Please use a signer on chain ID: ${routeChainId}`,
+          errorType: ErrorType.ValidationError
+        });
+      }
+
+      return { success: true };
+    } catch (error: unknown) {
+      if (error instanceof SquidError) {
+        return { success: false, error: error.message };
+      } else {
+        throw error; // Rethrow unexpected errors
+      }
+    }
+  }
 }
 
 export * from "./types";

--- a/src/test/check-signer-chain-compatibility.spec.ts 
+++ b/src/test/check-signer-chain-compatibility.spec.ts 
@@ -1,0 +1,99 @@
+import axios from "axios";
+import "dotenv/config";
+
+import { ethers } from "ethers";
+import { RouteData, Squid } from "../index";
+import { chainsData } from "./constants/chains";
+import { supportedTokens } from "./constants/tokens";
+
+jest.mock("axios");
+
+const privateKey = process.env.privateKey as string;
+const rpcEndPoint = process.env.ethereumRpcEndPoint as string; // be sure that rpc corresponds to env
+const provider = new ethers.providers.JsonRpcProvider(rpcEndPoint);
+
+async function setupTests() {
+  const signer = new ethers.Wallet(privateKey, provider);
+
+  const getMocked = jest.fn().mockResolvedValue({
+    data: {
+      chains: chainsData,
+      tokens: supportedTokens
+    },
+    status: 200
+  });
+  const mockedAxios = (axios.create as jest.Mock).mockReturnValue({
+    get: getMocked,
+    interceptors: {
+      response: {
+        use: jest.fn()
+      }
+    }
+  });
+
+  const signerChainId = await signer.getChainId();
+
+  const getSuccessRouteMocked = jest.fn().mockResolvedValue({
+    params: {
+      fromChain: signerChainId
+    }
+  });
+
+  const getErrorRouteMocked = jest.fn().mockResolvedValue({
+    params: {
+      fromChain: -1
+    }
+  });
+
+  const squidSdk = new Squid();
+
+  const successRoute = await getSuccessRouteMocked();
+  const errorRoute = await getErrorRouteMocked();
+
+  return {
+    signer,
+    squidSdk,
+    successRoute,
+    errorRoute
+  };
+}
+
+describe("SquidSDK - CheckSignerChainCompatibility function", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return an error message and `false` boolean if the signer and the route are not compatible", async () => {
+    const { signer, squidSdk, errorRoute } = await setupTests();
+
+    const result = await squidSdk.checkSignerChainCompatibility(
+      signer,
+      errorRoute
+    );
+
+    expect(result.success).toEqual(false);
+    expect(result.error).toBeDefined()
+  });
+
+  it("should return true if the signer and the route are compatible", async () => {
+    const { signer, squidSdk, successRoute } = await setupTests();
+
+    const result = await squidSdk.checkSignerChainCompatibility(
+      signer,
+      successRoute
+    );
+
+    expect(result.success).toEqual(true);
+  });
+
+
+  it("should throw a different error if there is an issue with the route", async () => {
+    const { signer, squidSdk } = await setupTests();
+
+    try {
+      await squidSdk.checkSignerChainCompatibility(signer, {} as RouteData);
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
# Description

Implemented functionality in the SDK to check if a signer is on the correct blockchain chain ID as specified in the route parameters. This addresses a common issue where developers, especially those new to cross-chain development, may mistakenly use a signer from an incorrect chain. The change aims to enhance developer experience by providing clear error messaging for such cases.

- closes 0xsquid/squid-core#222

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Tested?

Tested with unit tests in `src/test/check-signer-chain-compatibility.spec.ts` to ensure:
1. Returns error and `false` if the signer and route chain IDs don't match.
2. Returns `true` for matching signer and route chain IDs.
3. Handles unexpected errors gracefully.

## Evidence

Unit tests in `check-signer-chain-compatibility.spec.ts` serve as evidence for the functionality working as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
