### PR TITLE
chore: fix wrong version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsquid/sdk",
-  "version": "1.14.13",
+  "version": "1.14.14",
   "description": "🛠 An SDK for building applications on top of 0xsquid",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pr had been closed (but shouldn't be) https://github.com/0xsquid/squid-sdk/pull/280
Because current v1 npm version is https://www.npmjs.com/package/@0xsquid/sdk/v/1.14.14
So currently github action is throwing this error because of that
> ERROR fatal: tag 'v1.14.14' already exists