### PR TITLE
Chore/cosmos exec condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 
 
+## [1.14.16-beta.0](https://github.com/0xsquid/api-sdk/compare/v1.14.1...v1.14.16-beta.0) (2024-03-27)
+
+
+### Features
+
+* add chainId property to evm balances response ([#239](https://github.com/0xsquid/api-sdk/issues/239)) ([e5166c0](https://github.com/0xsquid/api-sdk/commit/e5166c01790ad18f4517e83b20698d190fa60759))
+* support injective network ([#279](https://github.com/0xsquid/api-sdk/issues/279)) ([42f09e6](https://github.com/0xsquid/api-sdk/commit/42f09e64b6dbff391278f27e4acd8172c1edae1a))
+
+
+### Bug Fixes
+
+* bignumber formatting ([#255](https://github.com/0xsquid/api-sdk/issues/255)) ([ea7a775](https://github.com/0xsquid/api-sdk/commit/ea7a7756767f4dd2c0a8b6ca23666e116b6fa0a6))
+* handle ledger amino messages ([#215](https://github.com/0xsquid/api-sdk/issues/215)) ([2ef50f7](https://github.com/0xsquid/api-sdk/commit/2ef50f76d2429cca74c71a1fd1324beff9a90f0c)), closes [#216](https://github.com/0xsquid/api-sdk/issues/216) [#224](https://github.com/0xsquid/api-sdk/issues/224)
+* handle possible undefined value that could throw bignumber error ([#261](https://github.com/0xsquid/api-sdk/issues/261)) ([5886f43](https://github.com/0xsquid/api-sdk/commit/5886f436faef9797d544a94d0200208fd716a363))
+* parse undefined memo sent from api ([#237](https://github.com/0xsquid/api-sdk/issues/237)) ([6d42fdd](https://github.com/0xsquid/api-sdk/commit/6d42fdd45afc33bb81b192fa3e1c42694f1c6ca7))
+* use a different rpc url for each chain ([#230](https://github.com/0xsquid/api-sdk/issues/230)) ([53bfa60](https://github.com/0xsquid/api-sdk/commit/53bfa60b9b314a7412b265fdea6e7de4454e49ea))
+* use all chains when no chains are specified ([#233](https://github.com/0xsquid/api-sdk/issues/233)) ([ca638dd](https://github.com/0xsquid/api-sdk/commit/ca638dd1aaa3395272788880fd0a195be55db525))
+
+
+### Reverts
+
+* Revert "chore: branch cut release for sdk v1.14.9" ([7497aaa](https://github.com/0xsquid/api-sdk/commit/7497aaade74c5af75b12291d8be57f10aa022601))
+
 ## [1.14.15](https://github.com/0xsquid/api-sdk/compare/v1.14.1...v1.14.15) (2024-03-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsquid/sdk",
-  "version": "1.14.15",
+  "version": "1.14.16-beta.0",
   "description": "🛠 An SDK for building applications on top of 0xsquid",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -535,13 +535,12 @@ export class Squid {
       ""
     );
     const gasMultiplier = Number(route.transactionRequest!.maxFeePerGas) || 1.3;
+    const fee = calculateFee(
+      Math.trunc(estimatedGas * gasMultiplier),
+      GasPrice.fromString(route.transactionRequest!.gasPrice)
+    );
 
     if (useBroadcast) {
-      const fee = calculateFee(
-        Math.trunc(estimatedGas * gasMultiplier),
-        GasPrice.fromString(route.transactionRequest!.gasPrice)
-      );
-
       return (signer as SigningCosmWasmClient).signAndBroadcast(
         signerAddress,
         [fromAminoMsg],
@@ -549,13 +548,11 @@ export class Squid {
         ""
       );
     }
+
     return (signer as SigningCosmWasmClient).sign(
       signerAddress,
       [fromAminoMsg],
-      calculateFee(
-        Math.trunc(estimatedGas * gasMultiplier),
-        GasPrice.fromString(route.transactionRequest!.gasPrice)
-      ),
+      fee,
       ""
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -542,14 +542,6 @@ export class Squid {
         GasPrice.fromString(route.transactionRequest!.gasPrice)
       );
 
-      console.log({
-        signerAddress,
-        fromAminoMsg,
-        fee,
-        estimatedGas,
-        gasMultiplier
-      });
-
       return (signer as SigningCosmWasmClient).signAndBroadcast(
         signerAddress,
         [fromAminoMsg],

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { toUtf8 } from "@cosmjs/encoding";
 import {
   AminoTypes,
   Coin,
+  DeliverTxResponse,
   GasPrice,
   SigningStargateClient,
   calculateFee,
@@ -313,8 +314,11 @@ export class Squid {
     signerAddress,
     route,
     executionSettings,
-    overrides
-  }: ExecuteRoute): Promise<ethers.providers.TransactionResponse | TxRaw> {
+    overrides,
+    useBroadcast = false
+  }: ExecuteRoute): Promise<
+    ethers.providers.TransactionResponse | TxRaw | DeliverTxResponse
+  > {
     this.validateInit();
 
     if (!route.transactionRequest) {
@@ -333,7 +337,8 @@ export class Squid {
       return await this.executeRouteCosmos(
         signer as SigningStargateClient,
         signerAddress!,
-        route
+        route,
+        useBroadcast
       );
     }
 
@@ -460,8 +465,9 @@ export class Squid {
   private async executeRouteCosmos(
     signer: SigningStargateClient | SigningCosmWasmClient,
     signerAddress: string,
-    route: RouteData
-  ): Promise<TxRaw> {
+    route: RouteData,
+    useBroadcast = false
+  ): Promise<TxRaw | DeliverTxResponse> {
     const cosmosMsg: CosmosMsg = JSON.parse(route.transactionRequest!.data);
     const msgs = [];
     switch (cosmosMsg.msgTypeUrl) {
@@ -530,6 +536,27 @@ export class Squid {
     );
     const gasMultiplier = Number(route.transactionRequest!.maxFeePerGas) || 1.3;
 
+    if (useBroadcast) {
+      const fee = calculateFee(
+        Math.trunc(estimatedGas * gasMultiplier),
+        GasPrice.fromString(route.transactionRequest!.gasPrice)
+      );
+
+      console.log({
+        signerAddress,
+        fromAminoMsg,
+        fee,
+        estimatedGas,
+        gasMultiplier
+      });
+
+      return (signer as SigningCosmWasmClient).signAndBroadcast(
+        signerAddress,
+        [fromAminoMsg],
+        fee,
+        ""
+      );
+    }
     return (signer as SigningCosmWasmClient).sign(
       signerAddress,
       [fromAminoMsg],

--- a/src/index.ts
+++ b/src/index.ts
@@ -326,13 +326,10 @@ export class Squid {
       });
     }
 
+    const isEvmChainId = Number(route.params.fromChain) > 0;
+
     // handle cosmos case
-    if (
-      signer instanceof SigningStargateClient ||
-      signer.constructor.name === "SigningStargateClient" ||
-      signer instanceof SigningCosmWasmClient ||
-      signer.constructor.name === "SigningCosmWasmClient"
-    ) {
+    if (!isEvmChainId) {
       return await this.executeRouteCosmos(
         signer as SigningStargateClient,
         signerAddress!,
@@ -382,7 +379,7 @@ export class Squid {
         fromAmount: params.fromAmount,
         fromChain,
         infiniteApproval: executionSettings?.infiniteApproval,
-        signer,
+        signer: signer as ethers.Signer,
         overrides: _overrides
       });
     }
@@ -402,7 +399,7 @@ export class Squid {
       };
     }
 
-    return await signer.sendTransaction(tx);
+    return await (signer as ethers.Signer).sendTransaction(tx);
   }
 
   public getRawTxHex({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -369,6 +369,7 @@ export type ExecuteRoute = {
     setGasPrice?: boolean;
   };
   overrides?: OverrideParams;
+  useBroadcast?: boolean;
 };
 
 export type Allowance = {


### PR DESCRIPTION
# Description

Add optional param `useBroadcast` to `executeRoute()` and `executeRouteCosmos()` methods.
When `useBroadcast: true`, `executeRouteCosmos()` uses `signer.signAndBroadcast()` instead of `signer.sign()` to sign transactions.

The purpose of this is that we are integrating Nomos, a multisig provider, and they reserve `sign()` for apps to verify user signatures, but instead override `signAndBroadcast()` to include their custom logic.


This PR also changes how we determine whether to use `executeRouteEvm()` or `executeRouteCosmos()`.
Now it parses `fromChain` from route params. If `fromChain` is a number, use `executeRouteEvm()`. If not, use `executeRouteCosmos()`.

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (code improvement)

# How Has This Been Tested?

Please describe the steps to test.

## Evidence

Please add some evidence like screenshots or records.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
