### PR TITLE
[v1] chore: increment cosmos gas multiplier to 1.5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -534,7 +534,7 @@ export class Squid {
       [fromAminoMsg],
       ""
     );
-    const gasMultiplier = Number(route.transactionRequest!.maxFeePerGas) || 1.3;
+    const gasMultiplier = Number(route.transactionRequest!.maxFeePerGas) || 1.5;
     const fee = calculateFee(
       Math.trunc(estimatedGas * gasMultiplier),
       GasPrice.fromString(route.transactionRequest!.gasPrice)


### PR DESCRIPTION
# Description

- Increase gas multiplier to 1.5 to resolve not enough gas issue on Nolus chain transactions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement)
- [ ] Styles (adding, editing or fixing styles)
- [ ] Unit test

# How Has This Been Tested?

- Nolus: NLS to Avalanche: AVAX

## Evidence

<img width="474" alt="image" src="https://github.com/0xsquid/squid-sdk/assets/89901304/06cac95b-cfc8-4a11-b44a-f0c195932d9b">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
