### PR TITLE
fix: catch errors getting evm balances

### DIFF
--- a/src/handlers/evm/utils.ts
+++ b/src/handlers/evm/utils.ts
@@ -138,15 +138,25 @@ export class Utils {
       );
 
       const getTokenData = async () => {
-        const balanceInWei =
-          await contract[isNativeToken ? "getEthBalance" : "balanceOf"](userAddress);
+        const { decimals, symbol, address, chainId } = token;
+
+        let balance: string;
+
+        try {
+          const balanceInWei =
+            await contract[isNativeToken ? "getEthBalance" : "balanceOf"](userAddress);
+
+          balance = balanceInWei.toString();
+        } catch (error) {
+          balance = "0";
+        }
 
         return {
-          balance: balanceInWei.toString(),
-          symbol: token.symbol,
-          address: token.address,
-          decimals: token.decimals,
-          chainId: token.chainId,
+          balance,
+          symbol,
+          address,
+          decimals,
+          chainId,
         };
       };
 


### PR DESCRIPTION
# Description

We are having an issue in the widget, where when an RPC call getting balances fails (for any reason), the sdk is not catching the error, and returns an empty array as tokens to the widget.

## Evidence
As soon as the RPC call fails, the widget is not showing the tokens.

https://github.com/0xsquid/squid-sdk/assets/98661193/eccc47e1-b35c-4e52-9005-a512be7bd353

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run the script below:
```ts
import { Squid } from "./src/index";

(async () => {
  try {
    const squid = new Squid({
      baseUrl: "https://apiplus.squidrouter.com",
      integratorId: "squid-swap-widget-v2",
    });

    await squid.init();

    const balance = await squid.getAllBalances({
      evmAddress: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
      chainIds: ["137"],
    });

    console.log({
      balance: balance.evmBalances?.map(b => ({ [b.symbol]: b.balance })),
    });
  } catch (error) {
    // @ts-ignore
    console.error(error.response.data);
  }
})();
```
Before the fix, the balances array is empty:

https://github.com/0xsquid/squid-sdk/assets/98661193/660ccc35-e126-47fe-8adf-b289103dccdf

After the fix, even though the rpc call failed, the balances array has all the tokens (with balance set to 0):

https://github.com/0xsquid/squid-sdk/assets/98661193/8cdbcd7f-9807-4394-b21a-76a335d39800

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
