### PR TITLE
fix: returns all tokens with zero balance when rpc call fails

### DIFF
--- a/src/services/getEvmBalances.ts
+++ b/src/services/getEvmBalances.ts
@@ -86,7 +86,10 @@ const getTokensBalanceSupportingMultiCall = async (
 
     return tokenBalances;
   } catch (error) {
-    return [];
+    return tokens.map(t => ({
+      ...t,
+      balance: "0",
+    }));
   }
 };
 
@@ -178,7 +181,10 @@ export const getAllEvmTokensBalance = async (
     return [...tokensMulticall, ...tokensNotMultiCall];
   } catch (error) {
     console.error(error);
-    return [];
+    return evmTokens.map(t => ({
+      ...t,
+      balance: "0",
+    }));
   }
 };
 

--- a/src/services/getEvmBalances.ts
+++ b/src/services/getEvmBalances.ts
@@ -88,7 +88,7 @@ const getTokensBalanceSupportingMultiCall = async (
   } catch (error) {
     return tokens.map(t => ({
       ...t,
-      balance: "0",
+      balance: "0"
     }));
   }
 };
@@ -183,7 +183,7 @@ export const getAllEvmTokensBalance = async (
     console.error(error);
     return evmTokens.map(t => ({
       ...t,
-      balance: "0",
+      balance: "0"
     }));
   }
 };


### PR DESCRIPTION
# Description

When getting evm balances, if the RPC call fails (usually the rpc is broken) the sdk returns an empty array for tokens, instead of tokens with balance: 0. This ends up in the widget displaying an empty tokens list:
![image](https://github.com/user-attachments/assets/f4d1d8e5-3f07-442c-84fb-8d9c23e4c121)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After the fix, the tokens load correctly (the underlying issue is not fixed though, the rpc is down)
![image](https://github.com/user-attachments/assets/212f73a9-2a8d-403f-acfd-ec2ff7758149)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
