### PR TITLE
chore: remove balance check before executing route

### DIFF
--- a/src/handlers/evm/index.ts
+++ b/src/handlers/evm/index.ts
@@ -1,5 +1,5 @@
-import { EthersAdapter } from "../../adapter/EthersAdapter";
 import erc20Abi from "../../abi/erc20.json";
+import { EthersAdapter } from "../../adapter/EthersAdapter";
 
 import {
   Contract,
@@ -20,8 +20,8 @@ import {
   NATIVE_EVM_TOKEN_ADDRESS,
   uint256MaxValue,
 } from "../../constants";
-import { Utils } from "./utils";
 import { TokensChains } from "../../utils/TokensChains";
+import { Utils } from "./utils";
 
 const ethersAdapter = new EthersAdapter();
 
@@ -32,6 +32,7 @@ export class EvmHandler extends Utils {
   }: {
     data: ExecuteRoute;
     params: RouteParamsPopulated;
+    bypassBalanceChecks?: boolean;
   }): Promise<TransactionResponse> {
     const {
       route: { transactionRequest },
@@ -45,13 +46,15 @@ export class EvmHandler extends Utils {
       overrides,
     });
 
-    await this.validateBalanceAndApproval({
-      data: {
-        ...data,
-        overrides: gasData,
-      },
-      params,
-    });
+    if (!data.bypassBalanceChecks) {
+      await this.validateBalanceAndApproval({
+        data: {
+          ...data,
+          overrides: gasData,
+        },
+        params,
+      });
+    }
 
     const tx = {
       to: target,

--- a/src/handlers/evm/index.ts
+++ b/src/handlers/evm/index.ts
@@ -32,7 +32,6 @@ export class EvmHandler extends Utils {
   }: {
     data: ExecuteRoute;
     params: RouteParamsPopulated;
-    bypassBalanceChecks?: boolean;
   }): Promise<TransactionResponse> {
     const {
       route: { transactionRequest },

--- a/src/handlers/evm/index.ts
+++ b/src/handlers/evm/index.ts
@@ -1,5 +1,5 @@
-import { EthersAdapter } from "../../adapter/EthersAdapter";
 import erc20Abi from "../../abi/erc20.json";
+import { EthersAdapter } from "../../adapter/EthersAdapter";
 
 import {
   Contract,
@@ -20,8 +20,8 @@ import {
   NATIVE_EVM_TOKEN_ADDRESS,
   uint256MaxValue,
 } from "../../constants";
-import { Utils } from "./utils";
 import { TokensChains } from "../../utils/TokensChains";
+import { Utils } from "./utils";
 
 const ethersAdapter = new EthersAdapter();
 
@@ -45,13 +45,10 @@ export class EvmHandler extends Utils {
       overrides,
     });
 
-    await this.validateBalanceAndApproval({
-      data: {
-        ...data,
-        overrides: gasData,
-      },
-      params,
-    });
+    const hasAllowance = await this.validateTokenAllowance({ data, params });
+    if (!hasAllowance) {
+      await this.approveRoute({ data, params });
+    }
 
     const tx = {
       to: target,
@@ -92,50 +89,6 @@ export class EvmHandler extends Utils {
         sender,
       });
     }
-  }
-
-  async validateBalanceAndApproval({
-    data,
-    params,
-  }: {
-    data: ExecuteRoute;
-    params: RouteParamsPopulated;
-  }): Promise<boolean> {
-    const wallet = data.signer as EvmWallet;
-
-    // support of multiple signers type and versions
-    let address = (wallet as any).address;
-
-    // ethers v5 & v6 support
-    try {
-      address = await wallet.getAddress();
-    } catch (error) {
-      // do nothing
-    }
-
-    // validate balance
-    await this.validateBalance({
-      sender: address,
-      params,
-    });
-
-    if (params.fromIsNative) {
-      return true;
-    }
-
-    const hasAllowance = await this.validateAllowance({
-      fromTokenContract: params.fromTokenContract as Contract,
-      sender: address,
-      router: (data.route.transactionRequest as OnChainExecutionData).target,
-      amount: BigInt(params.fromAmount),
-    });
-
-    // approve token spent if necessary
-    if (!hasAllowance) {
-      await this.approveRoute({ data, params });
-    }
-
-    return true;
   }
 
   async approveRoute({

--- a/src/handlers/evm/utils.ts
+++ b/src/handlers/evm/utils.ts
@@ -1,18 +1,9 @@
 import { ChainData, OnChainExecutionData, Token } from "@0xsquid/squid-types";
 
-import { Provider, ethers } from "ethers";
+import { OverrideParams, Contract, GasData, RpcProvider, TokenBalance } from "../../types";
 import { MulticallWrapper } from "ethers-multicall-provider";
-import { MULTICALL_ADDRESS, NATIVE_EVM_TOKEN_ADDRESS, multicallAbi } from "../../constants";
-import {
-  Contract,
-  EvmWallet,
-  ExecuteRoute,
-  GasData,
-  OverrideParams,
-  RouteParamsPopulated,
-  RpcProvider,
-  TokenBalance,
-} from "../../types";
+import { Provider, ethers } from "ethers";
+import { multicallAbi, MULTICALL_ADDRESS, NATIVE_EVM_TOKEN_ADDRESS } from "../../constants";
 
 export class Utils {
   async validateNativeBalance({
@@ -256,33 +247,5 @@ export class Utils {
     } catch (error) {
       return null;
     }
-  }
-
-  async validateTokenAllowance({
-    params,
-    data,
-  }: {
-    params: RouteParamsPopulated;
-    data: ExecuteRoute;
-  }): Promise<boolean> {
-    if (params.fromIsNative) {
-      return true;
-    }
-
-    const wallet = data.signer as EvmWallet;
-    let address = (wallet as any).address;
-
-    try {
-      address = await wallet.getAddress();
-    } catch (error) {
-      // do nothing
-    }
-
-    return await this.validateAllowance({
-      fromTokenContract: params.fromTokenContract as Contract,
-      sender: address,
-      router: (data.route.transactionRequest as OnChainExecutionData).target,
-      amount: BigInt(params.fromAmount),
-    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,10 @@ export class Squid extends TokensChains {
           data.signer as EvmWallet,
         );
 
-        return this.handlers.evm.executeRoute({ data, params: evmParams });
+        return this.handlers.evm.executeRoute({
+          data,
+          params: evmParams,
+        });
 
       case ChainType.COSMOS:
         const cosmosParams = this.handlers.cosmos.populateRouteParams(this, data.route.params);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,14 @@
 import {
-  ChainData,
-  Token,
-  RouteRequest,
   RouteResponse as _RouteResponse,
+  ChainData,
   DepositAddressResponse,
+  RouteRequest,
+  Token,
 } from "@0xsquid/squid-types";
 import { SigningStargateClient } from "@cosmjs/stargate";
 
-import { EvmWallet, TransactionResponse, RpcProvider, Contract, GasData } from "./ethers";
 import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { Contract, EvmWallet, GasData, RpcProvider, TransactionResponse } from "./ethers";
 
 export * from "@0xsquid/squid-types";
 export * from "./cosmos";
@@ -42,6 +42,7 @@ export type ExecuteRoute = {
   route: _RouteResponse["route"];
   executionSettings?: ExecutionSettings;
   overrides?: OverrideParams;
+  bypassBalanceChecks?: boolean;
   signerAddress?: string; // cosmos specific
 };
 


### PR DESCRIPTION
### Goal: Remove balance check before route execution - avoid RPC rate limiting
The wallet is already doing a balance check 
- add new param to route execution: `bypassBalanceChecks`

