### PR TITLE
chore: add chainId param when sending evm transaction

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Cache yarn dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ hashFiles('**/yarn.lock') }}

--- a/src/adapter/HttpAdapter.ts
+++ b/src/adapter/HttpAdapter.ts
@@ -9,7 +9,7 @@ export default class HttpAdapter {
   constructor(config: RequestConfig) {
     this.axios = axios.create({
       ...omit(config, ["config"]),
-      baseURL: config?.baseUrl,
+      baseURL: config?.baseURL,
       timeout: config?.timeout,
     });
 
@@ -20,7 +20,7 @@ export default class HttpAdapter {
 
   setConfig(config: RequestConfig) {
     if (!config) throw new Error("config object undefined");
-    this.axios = axios.create({ ...config, baseURL: config.baseUrl });
+    this.axios = axios.create({ ...config, baseURL: config.baseURL });
   }
 
   get = async (url: string, config?: { [key: string]: any }): Promise<HttpResponse> => {

--- a/src/adapter/HttpAdapter.ts
+++ b/src/adapter/HttpAdapter.ts
@@ -20,7 +20,7 @@ export default class HttpAdapter {
 
   setConfig(config: RequestConfig) {
     if (!config) throw new Error("config object undefined");
-    this.axios = axios.create({ ...config, baseURL: config.baseURL });
+    this.axios = axios.create(config);
   }
 
   get = async (url: string, config?: { [key: string]: any }): Promise<HttpResponse> => {

--- a/src/handlers/evm/index.spec.ts
+++ b/src/handlers/evm/index.spec.ts
@@ -61,6 +61,9 @@ describe("EvmHandler", () => {
   } as unknown as ExecuteRoute;
   const params = {
     fromAmount: "10000000000000000",
+    fromChain: {
+      chainId: "1",
+    },
   } as unknown as RouteParamsPopulated;
 
   describe("executeRoute method", () => {

--- a/src/handlers/evm/index.ts
+++ b/src/handlers/evm/index.ts
@@ -59,6 +59,7 @@ export class EvmHandler extends Utils {
       to: target,
       data: _data,
       value,
+      chainId: Number(params.fromChain.chainId),
       ...gasData,
     } as TransactionRequest;
 
@@ -178,6 +179,7 @@ export class EvmHandler extends Utils {
     return (data.signer as EvmWallet).sendTransaction({
       to: params.preHook ? params.preHook.fundToken : params.fromToken.address,
       data: approveData,
+      chainId: Number(params.fromChain.chainId),
       ...overrides,
     });
   }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -67,7 +67,7 @@ describe("Squid", () => {
         toToken: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         fromAddress: "0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5",
         toAddress: "0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5",
-        fromAmount: "5000000000000",
+        fromAmount: "1000000000000000000",
         slippage: 1.5,
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export class Squid extends TokensChains {
     }
 
     this.httpInstance = new HttpAdapter({
-      baseUrl: config?.baseUrl || baseUrl,
+      baseURL: config?.baseUrl || baseUrl,
       config,
       headers: {
         "x-integrator-id": config.integratorId,
@@ -69,7 +69,7 @@ export class Squid extends TokensChains {
 
   setConfig(config: Config) {
     this.httpInstance = new HttpAdapter({
-      baseUrl: config?.baseUrl || baseUrl,
+      baseURL: config?.baseUrl || baseUrl,
       config,
       headers: {
         "x-integrator-id": config.integratorId || "squid-sdk",

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -4,7 +4,7 @@ import { Config } from ".";
 export type HttpResponse = AxiosResponse;
 
 export interface RequestConfig {
-  baseUrl?: string;
+  baseURL?: string;
   config?: Config;
   headers?: Record<string, string | number | boolean>;
   timeout?: number;


### PR DESCRIPTION
### Description

In some rare cases, when a browser has multiple tabs of the same website open, some wallets need the `chainId` to be defined to prevent transactions from being sent to the wrong network.


- add `chainId` param to evm transactions
- fix tests
  - add missing route properties
  - rename axios' `baseUrl` to `baseURL`
  - ![image](https://github.com/user-attachments/assets/75411378-5031-4e98-a2f2-23d91133e78c)
