### PR TITLE
fix: resolve form-data vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mysten/sui": "1.21.2",
     "@mysten/wallet-standard": "0.14.0",
     "@project-serum/anchor": "^0.26.0",
-    "axios": "^1.8.2",
+    "axios": "^1.10.0",
     "cosmjs-types": "0.9.0",
     "ethers": "6.13.5",
     "ethers-multicall-provider": "^5.0.0",
@@ -42,7 +42,8 @@
   },
   "resolutions": {
     "semver": "^7.5.4",
-    "axios": "^1.8.2"
+    "axios": "^1.10.0",
+    "form-data": "^4.0.4"
   },
   "devDependencies": {
     "@0xsquid/squid-types": "0.1.162",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,10 +2551,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.6.0, axios@^1.8.2:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
-  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
+axios@^1.10.0, axios@^1.6.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
+  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -4071,14 +4071,15 @@ for-each@^0.3.3, for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-form-data@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
-  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+form-data@^4.0.0, form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:


### PR DESCRIPTION
## Summary
- Update axios to v1.10.0 to get updated form-data dependency
- Add form-data resolution to force version 4.0.4 which includes security fix
- Resolves critical vulnerability CVE in form-data package

## Test plan
- [x] Verified form-data is now at version 4.0.4
- [x] Ran yarn audit - no form-data vulnerabilities found
- [x] Dependencies install successfully