### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ !contains('["major","minor", "patch", "premajor", "preminor", "prerelease", "prepatch"]', github.event.inputs.release-type) }}
 
       - name: Checkout ${{ github.event.inputs.branch-name }} for ${{ github.event.inputs.release-type }} release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: ${{ github.event.inputs.branch-name != 'main' }}
         with:
           ref: ${{ github.event.inputs.branch-name }}
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout main for ${{ github.event.inputs.release-type }} release
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: ${{ github.event.inputs.branch-name == 'main' }}
         with:
           ref: main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0