### PR TITLE
fix: secure release-cut workflow permissions and auth checks

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -33,6 +33,10 @@ on:
           - alpha
           - beta
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   cut-release:
     if: github.repository_owner == '0xsquid' && contains(fromJSON('["0x0Koda", "rajat43", "odcey", "genaroibc"]'), github.actor)

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -35,13 +35,13 @@ on:
 
 jobs:
   cut-release:
-    if: contains('["0x0Koda", "rajat43", "jmdev3", "odcey", "genaroibc"]', github.actor)
+    if: github.repository_owner == '0xsquid' && contains(fromJSON('["0x0Koda", "rajat43", "odcey", "genaroibc"]'), github.actor)
     name: Create release branch and PRs into ${{ github.event.inputs.branch-name }}
     runs-on: ubuntu-latest
     steps:
       - name: Exit if release type argument is invalid
         run: exit 1
-        if: ${{ !contains('["major","minor", "patch", "premajor", "preminor", "prerelease", "prepatch"]', github.event.inputs.release-type) }}
+        if: ${{ !contains(fromJSON('["major", "minor", "patch", "premajor", "preminor", "prerelease", "prepatch"]'), github.event.inputs.release-type) }}
 
       - name: Checkout ${{ github.event.inputs.branch-name }} for ${{ github.event.inputs.release-type }} release
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Switch `contains()` from string-based substring matching to `fromJSON()` array-based exact matching
- Remove stale team member `jmdev3` from authorized users list
- Add `repository_owner` org guard
- Add explicit `GITHUB_TOKEN` permissions block (contents: write, pull-requests: write)